### PR TITLE
Improve yaml property access

### DIFF
--- a/src/main/java/com/uber/profiling/YamlConfigProvider.java
+++ b/src/main/java/com/uber/profiling/YamlConfigProvider.java
@@ -157,19 +157,18 @@ public class YamlConfigProvider implements ConfigProvider {
     
     private static void addConfig(Map<String, Map<String, List<String>>> config, String override, String key, Object value) {
         Map<String, List<String>> configMap = config.computeIfAbsent(override, k -> new HashMap<>());
+        List<String> configValueList = configMap.computeIfAbsent(key, k -> new ArrayList<>());
         
         if (value instanceof List) {
-            int count = 0;
             for (Object entry : (List)value) {
-                configMap.put(key + "[" + count++ + "]", Arrays.asList(entry.toString()));
+                configValueList.add(entry.toString());
             }
         } else if (value instanceof Object[]) {
-            int count = 0;
             for (Object entry : (Object[])value) {
-                configMap.put(key + "[" + count++ + "]", Arrays.asList(entry.toString()));
+                configValueList.add(entry.toString());
             }
         } else {
-            configMap.put(key, Arrays.asList(value.toString()));
+            configValueList.add(value.toString());
         }
     }
     

--- a/src/main/java/com/uber/profiling/YamlConfigProvider.java
+++ b/src/main/java/com/uber/profiling/YamlConfigProvider.java
@@ -138,7 +138,13 @@ public class YamlConfigProvider implements ConfigProvider {
                         }
                         
                         Map<Object, Object> overrideValues = (Map<Object, Object>)valueObj;
-                        addConfig(result, overrideKey, OVERRIDE_KEY + "." + overrideKey, overrideValues);
+                        for (Map.Entry<Object, Object> entry : overrideValues.entrySet()) {
+                            if (entry.getValue() == null) {
+                                continue;
+                            }
+                            String configKey = entry.getKey().toString();
+                            addConfig(result, overrideKey, configKey, entry.getValue());
+                        }
                     }
                 }
 

--- a/src/main/java/com/uber/profiling/YamlConfigProvider.java
+++ b/src/main/java/com/uber/profiling/YamlConfigProvider.java
@@ -158,13 +158,14 @@ public class YamlConfigProvider implements ConfigProvider {
     
     private static void addConfig(Map<String, Map<String, List<String>>> config, String override, String key, Object value) {
         Map<String, List<String>> configMap = config.computeIfAbsent(override, k -> new HashMap<>());
-        List<String> configValueList = configMap.computeIfAbsent(key, k -> new ArrayList<>());
         
         if (value instanceof List) {
+            List<String> configValueList = configMap.computeIfAbsent(key, k -> new ArrayList<>());
             for (Object entry : (List)value) {
                 configValueList.add(entry.toString());
             }
         } else if (value instanceof Object[]) {
+            List<String> configValueList = configMap.computeIfAbsent(key, k -> new ArrayList<>());      
             for (Object entry : (Object[])value) {
                 configValueList.add(entry.toString());
             }
@@ -176,8 +177,8 @@ public class YamlConfigProvider implements ConfigProvider {
                     addConfig(config, override, key + "." + propKey, propValue);
                  }
             }
-            configMap.values().removeIf(List::isEmpty);
         } else {
+            List<String> configValueList = configMap.computeIfAbsent(key, k -> new ArrayList<>());
             configValueList.add(value.toString());
         }
     }

--- a/src/main/java/com/uber/profiling/YamlConfigProvider.java
+++ b/src/main/java/com/uber/profiling/YamlConfigProvider.java
@@ -29,7 +29,6 @@ import java.io.ByteArrayInputStream;
 import java.net.HttpURLConnection;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -121,11 +120,7 @@ public class YamlConfigProvider implements ConfigProvider {
                             logger.warn("Invalid override property: " + valueObj);
                         }
                     } else {
-                        if (valueObj instanceof Map) {
-                            addMapConfig(result, "", configKey, (Map)valueObj);
-                        }else{
-                            addConfig(result, "", configKey, valueObj);
-                        }
+                        addConfig(result, "", configKey, valueObj);
                     }
                 }
                 
@@ -143,7 +138,7 @@ public class YamlConfigProvider implements ConfigProvider {
                         }
                         
                         Map<Object, Object> overrideValues = (Map<Object, Object>)valueObj;
-                        addMapConfig(result, overrideKey, OVERRIDE_KEY + "." + overrideKey, overrideValues);
+                        addConfig(result, overrideKey, OVERRIDE_KEY + "." + overrideKey, overrideValues);
                     }
                 }
 
@@ -167,22 +162,17 @@ public class YamlConfigProvider implements ConfigProvider {
             for (Object entry : (Object[])value) {
                 configValueList.add(entry.toString());
             }
+         } else if (value instanceof Map) {
+            for (Object mapKey : ((Map)value).keySet()) {
+                String propKey = mapKey.toString();
+                Object propValue = ((Map)value).get(propKey);
+                if (propValue != null) {
+                    addConfig(config, override, key + "." + propKey, propValue);
+                 }
+            }
+            configMap.values().removeIf(List::isEmpty);
         } else {
             configValueList.add(value.toString());
-        }
-    }
-    
-    private static void addMapConfig(Map<String, Map<String, List<String>>> result, String override, String configKey, Map valueObj) {
-        for (Object key : valueObj.keySet()) {
-            String propKey = key.toString();
-            Object propValue = valueObj.get(propKey);
-            if (propValue != null) {
-                if (propValue instanceof Map) {
-                    addMapConfig(result, override, configKey + "." + propKey, (Map) propValue);
-                } else {
-                    addConfig(result, override, configKey + "." + propKey, propValue);
-                }
-            }
         }
     }
 

--- a/src/test/java/com/uber/profiling/YamlConfigProviderTest.java
+++ b/src/test/java/com/uber/profiling/YamlConfigProviderTest.java
@@ -62,12 +62,19 @@ public class YamlConfigProviderTest {
                     "key2:\n" +
                     "- value2a\n" +
                     "- value2b\n" +
+                    "key3:\n" +
+                    "    key3a: value3a\n" +
+                    "    key3b:\n" +
+                    "    - value3b\n" +
+                    "    - value3c\n" +
                     "override:\n" +
                     "  override1: \n" +
                     "    key1: value11\n" +
                     "    key2:\n" +
                     "    - value22a\n" +
                     "    - value22b\n" +
+                    "    key3:\n" +
+                    "      key3a: value33a\n" +
                     "";
             Files.write(file.toPath(), content.getBytes(), StandardOpenOption.CREATE);
 
@@ -76,14 +83,20 @@ public class YamlConfigProviderTest {
             Assert.assertEquals(2, config.size());
 
             Map<String, List<String>> rootConfig = config.get("");
-            Assert.assertEquals(2, rootConfig.size());
+            Assert.assertEquals(6, rootConfig.size());
             Assert.assertEquals(Arrays.asList("value1"), rootConfig.get("key1"));
-            Assert.assertEquals(Arrays.asList("value2a", "value2b"), rootConfig.get("key2"));
+            Assert.assertEquals(Arrays.asList("value2a"), rootConfig.get("key2[0]"));
+            Assert.assertEquals(Arrays.asList("value2b"), rootConfig.get("key2[1]"));
+            Assert.assertEquals(Arrays.asList("value3a"), rootConfig.get("key3.key3a"));
+            Assert.assertEquals(Arrays.asList("value3b"), rootConfig.get("key3.key3b[0]"));
+            Assert.assertEquals(Arrays.asList("value3c"), rootConfig.get("key3.key3b[1]"));
 
             Map<String, List<String>> override1Config = config.get("override1");
-            Assert.assertEquals(2, override1Config.size());
-            Assert.assertEquals(Arrays.asList("value11"), override1Config.get("key1"));
-            Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("key2"));
+            Assert.assertEquals(4, override1Config.size());
+            Assert.assertEquals(Arrays.asList("value11"), override1Config.get("override.override1.key1"));
+            Assert.assertEquals(Arrays.asList("value22a"), override1Config.get("override.override1.key2[0]"));
+            Assert.assertEquals(Arrays.asList("value22b"), override1Config.get("override.override1.key2[1]"));
+            Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("override.override1.key3.key3a"));
         }
     }
 
@@ -100,12 +113,19 @@ public class YamlConfigProviderTest {
                 "key2:\n" +
                 "- value2a\n" +
                 "- value2b\n" +
+                "key3:\n" +
+                "    key3a: value3a\n" +
+                "    key3b:\n" +
+                "    - value3b\n" +
+                "    - value3c\n" +
                 "override:\n" +
                 "  override1: \n" +
                 "    key1: value11\n" +
                 "    key2:\n" +
                 "    - value22a\n" +
                 "    - value22b\n" +
+                "    key3:\n" +
+                "      key3a: value33a\n" +
                 "";
         
         Path path = Files.createTempFile("jvm-profiler_", ".yaml");
@@ -117,13 +137,19 @@ public class YamlConfigProviderTest {
         Assert.assertEquals(2, config.size());
 
         Map<String, List<String>> rootConfig = config.get("");
-        Assert.assertEquals(2, rootConfig.size());
+        Assert.assertEquals(6, rootConfig.size());
         Assert.assertEquals(Arrays.asList("value1"), rootConfig.get("key1"));
-        Assert.assertEquals(Arrays.asList("value2a", "value2b"), rootConfig.get("key2"));
+        Assert.assertEquals(Arrays.asList("value2a"), rootConfig.get("key2[0]"));
+        Assert.assertEquals(Arrays.asList("value2b"), rootConfig.get("key2[1]"));
+        Assert.assertEquals(Arrays.asList("value3a"), rootConfig.get("key3.key3a"));
+        Assert.assertEquals(Arrays.asList("value3b"), rootConfig.get("key3.key3b[0]"));
+        Assert.assertEquals(Arrays.asList("value3c"), rootConfig.get("key3.key3b[1]"));
 
         Map<String, List<String>> override1Config = config.get("override1");
-        Assert.assertEquals(2, override1Config.size());
-        Assert.assertEquals(Arrays.asList("value11"), override1Config.get("key1"));
-        Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("key2"));
+        Assert.assertEquals(4, override1Config.size());
+        Assert.assertEquals(Arrays.asList("value11"), override1Config.get("override.override1.key1"));
+        Assert.assertEquals(Arrays.asList("value22a"), override1Config.get("override.override1.key2[0]"));
+        Assert.assertEquals(Arrays.asList("value22b"), override1Config.get("override.override1.key2[1]"));
+        Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("override.override1.key3.key3a"));
     }
 }

--- a/src/test/java/com/uber/profiling/YamlConfigProviderTest.java
+++ b/src/test/java/com/uber/profiling/YamlConfigProviderTest.java
@@ -91,9 +91,9 @@ public class YamlConfigProviderTest {
 
             Map<String, List<String>> override1Config = config.get("override1");
             Assert.assertEquals(3, override1Config.size());
-            Assert.assertEquals(Arrays.asList("value11"), override1Config.get("override.override1.key1"));
-            Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("override.override1.key2"));
-            Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("override.override1.key3.key3a"));
+            Assert.assertEquals(Arrays.asList("value11"), override1Config.get("key1"));
+            Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("key2"));
+            Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("key3.key3a"));
         }
     }
 
@@ -141,8 +141,8 @@ public class YamlConfigProviderTest {
 
         Map<String, List<String>> override1Config = config.get("override1");
         Assert.assertEquals(3, override1Config.size());
-        Assert.assertEquals(Arrays.asList("value11"), override1Config.get("override.override1.key1"));
-        Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("override.override1.key2"));
-        Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("override.override1.key3.key3a"));
+        Assert.assertEquals(Arrays.asList("value11"), override1Config.get("key1"));
+        Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("key2"));
+        Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("key3.key3a"));
     }
 }

--- a/src/test/java/com/uber/profiling/YamlConfigProviderTest.java
+++ b/src/test/java/com/uber/profiling/YamlConfigProviderTest.java
@@ -83,19 +83,16 @@ public class YamlConfigProviderTest {
             Assert.assertEquals(2, config.size());
 
             Map<String, List<String>> rootConfig = config.get("");
-            Assert.assertEquals(6, rootConfig.size());
+            Assert.assertEquals(4, rootConfig.size());
             Assert.assertEquals(Arrays.asList("value1"), rootConfig.get("key1"));
-            Assert.assertEquals(Arrays.asList("value2a"), rootConfig.get("key2[0]"));
-            Assert.assertEquals(Arrays.asList("value2b"), rootConfig.get("key2[1]"));
+            Assert.assertEquals(Arrays.asList("value2a", "value2b"), rootConfig.get("key2"));
             Assert.assertEquals(Arrays.asList("value3a"), rootConfig.get("key3.key3a"));
-            Assert.assertEquals(Arrays.asList("value3b"), rootConfig.get("key3.key3b[0]"));
-            Assert.assertEquals(Arrays.asList("value3c"), rootConfig.get("key3.key3b[1]"));
+            Assert.assertEquals(Arrays.asList("value3b", "value3c"), rootConfig.get("key3.key3b"));
 
             Map<String, List<String>> override1Config = config.get("override1");
-            Assert.assertEquals(4, override1Config.size());
+            Assert.assertEquals(3, override1Config.size());
             Assert.assertEquals(Arrays.asList("value11"), override1Config.get("override.override1.key1"));
-            Assert.assertEquals(Arrays.asList("value22a"), override1Config.get("override.override1.key2[0]"));
-            Assert.assertEquals(Arrays.asList("value22b"), override1Config.get("override.override1.key2[1]"));
+            Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("override.override1.key2"));
             Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("override.override1.key3.key3a"));
         }
     }
@@ -137,19 +134,15 @@ public class YamlConfigProviderTest {
         Assert.assertEquals(2, config.size());
 
         Map<String, List<String>> rootConfig = config.get("");
-        Assert.assertEquals(6, rootConfig.size());
+        Assert.assertEquals(4, rootConfig.size());
         Assert.assertEquals(Arrays.asList("value1"), rootConfig.get("key1"));
-        Assert.assertEquals(Arrays.asList("value2a"), rootConfig.get("key2[0]"));
-        Assert.assertEquals(Arrays.asList("value2b"), rootConfig.get("key2[1]"));
-        Assert.assertEquals(Arrays.asList("value3a"), rootConfig.get("key3.key3a"));
-        Assert.assertEquals(Arrays.asList("value3b"), rootConfig.get("key3.key3b[0]"));
-        Assert.assertEquals(Arrays.asList("value3c"), rootConfig.get("key3.key3b[1]"));
+        Assert.assertEquals(Arrays.asList("value2a", "value2b"), rootConfig.get("key2"));
+        Assert.assertEquals(Arrays.asList("value3b", "value3c"), rootConfig.get("key3.key3b"));
 
         Map<String, List<String>> override1Config = config.get("override1");
-        Assert.assertEquals(4, override1Config.size());
+        Assert.assertEquals(3, override1Config.size());
         Assert.assertEquals(Arrays.asList("value11"), override1Config.get("override.override1.key1"));
-        Assert.assertEquals(Arrays.asList("value22a"), override1Config.get("override.override1.key2[0]"));
-        Assert.assertEquals(Arrays.asList("value22b"), override1Config.get("override.override1.key2[1]"));
+        Assert.assertEquals(Arrays.asList("value22a", "value22b"), override1Config.get("override.override1.key2"));
         Assert.assertEquals(Arrays.asList("value33a"), override1Config.get("override.override1.key3.key3a"));
     }
 }


### PR DESCRIPTION
It will be better if yaml properties can be accessed using dot (".") notation. Current implementation stores Map and List from yaml in String format which is not very convenient while using these properties. Consider below yaml properties.
```
key1: value1
key3:
    key3a: value3a
    key3b:
    - value3b
    - value3c
override:
  override1: 
    key1: value11
    key3:
      key3a: value33a
```	  	  
Currently YamlConfigProvider stores them in `Map<String, Map<String, List<String>>>` which is like below.
```
{
		 = {
		key1 = [value1],
		key3 = [{
				key3a = value3a,
				key3b = [value3b, value3c]
			}
		]
	},
	override1 = {
		key1 = [value11],
		key3 = [{
				key3a = value33a
			}
		]
	}
```
The proposed change will store them in same `Map<String, Map<String, List<String>>>` which will be like below. 
```
{
		 = {
		key1 = [value1],
		key3.key3a = [value3a],
		key3.key3b[0] = [value3b],
		key3.key3b[1] = [value3c]
	},
	override1 = {
		override.override1.key1 = [value11],
		override.override1.key3.key3a = [value33a]
	}
}
```
This is similar format how [Spring loads yaml](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-loading-yaml) file. This change will still store the values in `List<String>` so it won't break existing functionalities. I have updated YamlConfigProviderTest class for this change. 