### PR TITLE
SparkUtils.getSparkEnvAppId using the wrong method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-
+dist: trusty
 jdk:
   - oraclejdk8
   - openjdk8

--- a/src/main/java/com/uber/profiling/util/SparkUtils.java
+++ b/src/main/java/com/uber/profiling/util/SparkUtils.java
@@ -59,7 +59,7 @@ public class SparkUtils {
         try {
             Object result = ReflectionUtils.executeStaticMethods(
                     className, 
-                    "get.conf.getSparkEnvAppId");
+                    "get.conf.getAppId");
             if (result == null) {
                 return null;
             }


### PR DESCRIPTION
I've been using the profiler locally and noticed that my `MethodArgument.json` had null `appId` fields.

I believe that `SparkUtils.getSparkEnvAppId` is invoking the incorrect method in Spark.

I've made tested the change on this PR locally and have confirmed that I no longer have null `appId` fields locally.

Please let me know if I've misunderstood or if further changes are needed for this change to be accepted.