### PR TITLE
Avoid creation of multiple reporters

### DIFF
--- a/src/main/java/com/uber/profiling/Arguments.java
+++ b/src/main/java/com/uber/profiling/Arguments.java
@@ -59,6 +59,7 @@ public class Arguments {
     private boolean noop = false;
     
     private Constructor<Reporter> reporterConstructor;
+    private Reporter reporter;
     private Constructor<ConfigProvider> configProviderConstructor;
     private String configFile;
 
@@ -260,11 +261,12 @@ public class Arguments {
     }
 
     public Reporter getReporter() {
+        if (reporter != null) return reporter; 
         if (reporterConstructor == null) {
             return new ConsoleOutputReporter();
         } else {
             try {
-                Reporter reporter = reporterConstructor.newInstance();
+                reporter = reporterConstructor.newInstance();
                 reporter.updateArguments(getRawArgValues());
                 return reporter;
             } catch (Throwable e) {


### PR DESCRIPTION
Due to an ambiguous semantic of the `getReporter` method of the `Arguments` class, extensions created around this project are forced to be using different reporters instances for their collectors and for the collectors in this repository. This prevents the reporter created for others' collectors to follow the proper lifecycle and hence to be correctly closed when needed, or anyway, makes them responsible to do so.