### PR TITLE
add debug message

### DIFF
--- a/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
+++ b/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
@@ -9,8 +9,10 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Metrics reporter class for Graphite.
@@ -39,6 +41,8 @@ public class GraphiteOutputReporter implements Reporter {
   private Socket socket = null;
   private PrintWriter out = null;
 
+  private Set whiteList = new HashSet();
+
   @Override
   public void report(String profilerName, Map<String, Object> metrics) {
     // get DB connection
@@ -63,13 +67,15 @@ public class GraphiteOutputReporter implements Reporter {
     long timestamp = System.currentTimeMillis() / 1000;
     for (Map.Entry<String, Object> entry : formattedMetrics.entrySet()) {
       try {
-        out.printf(
-            newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+        if (whiteList.contains(entry.getKey())) {
+          out.printf(
+              newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+        }
       } catch (Exception e) {
-        logger.warn("Unable to print metrics, newPrefix="+newPrefix
-            +", entry.getKey()= "+ entry.getKey()
-            +", entry.getValue()= "+ entry.getValue()
-            +", timestamp= "+ timestamp);
+        logger.warn("Unable to print metrics, newPrefix=" + newPrefix
+            + ", entry.getKey()= " + entry.getKey()
+            + ", entry.getValue()= " + entry.getValue()
+            + ", timestamp= " + timestamp);
       }
     }
   }
@@ -193,6 +199,13 @@ public class GraphiteOutputReporter implements Reporter {
         } else if (key.equals("graphite.prefix")) {
           logger.info("Got value for database = " + stringValue);
           this.prefix = stringValue;
+        } else if (key.equals("graphite.whiteList")) {
+          logger.info("Got value for whiteList = " + stringValue);
+          if (stringValue != null && stringValue.length() > 0) {
+            for (String pattern : stringValue.split(",")) {
+              this.whiteList.add(pattern.trim());
+            }
+          }
         }
       }
     }

--- a/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
+++ b/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
@@ -62,8 +62,15 @@ public class GraphiteOutputReporter implements Reporter {
     formattedMetrics.remove("processUuid");
     long timestamp = System.currentTimeMillis() / 1000;
     for (Map.Entry<String, Object> entry : formattedMetrics.entrySet()) {
-      out.printf(
-          newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+      try {
+        out.printf(
+            newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+      } catch (Exception e) {
+        logger.warn("Unable to print metrics, newPrefix="+newPrefix
+            +", entry.getKey()= "+ entry.getKey()
+            +", entry.getValue()= "+ entry.getValue()
+            +", timestamp= "+ timestamp);
+      }
     }
   }
 


### PR DESCRIPTION
I'm sorry, I find `formattedMetrics` contains a `cmdline` metric, which may have unexpected character, so we need to catch the unexpected exception.

```
[WARNING] 1572856668498 com.uber.profiling.reporters.GraphiteOutputReporter: Unable to print metrics, newPrefix=java.spark2.application_1571027248623_16676.prd-zboffline-019-prd-leyantech-com.b8b52afe-5613-46a3-8b50-547aa005f290, entry.getKey()= cmdline, entry.getValue()= /usr/java/jdk1.8.0_191-amd64/bin/java -server -Xmx12288m -Dapp.id=229 -Dapp_name=step-trade-attribution -Denv=prdzb -Dhadoop_user_name=schedule -Dkafka_brokers=192.168.17.224:9092,192.168.17.225:9092,192.168.17.226:9092 -Dstatsd_host=192.168.17.163 -javaagent:jvm-profiler-1.0.0.jar=reporter=com.uber.profiling.reporters.GraphiteOutputReporter,configProvider=com.uber.profiling.YamlConfigProvider,configFile=spark2_graphite.yaml -Dprdzb_meta=http://192.168.17.232:8080 -Djava.io.tmpdir=/data9/yarn/nm/usercache/schedule/appcache/application_1571027248623_16676/container_e28_1571027248623_16676_01_000002/tmp -Dspark.network.crypto.enabled=false -Dspark.authenticate=false -Dspark.shuffle.service.port=7337 -Dspark.ui.port=0 -Dspark.driver.port=35306 -Dspark.yarn.app.container.log.dir=/data6/yarn/container-logs/application_1571027248623_16676/container_e28_1571027248623_16676_01_000002 -XX:OnOutOfMemoryError=kill %p org.apache.spark.executor.CoarseGrainedExecutorBackend --driver-url spark://CoarseGrainedScheduler@prd-zboffline-021.prd.leyantech.com:35306 --executor-id 1 --hostname prd-zboffline-019.prd.leyantech.com --cores 6 --app-id application_1571027248623_16676 --user-class-path file:/data9/yarn/nm/usercache/schedule/appcache/application_1571027248623_16676/container_e28_1571027248623_16676_01_000002/__app__.jar --user-class-path file:/data9/yarn/nm/usercache/schedule/appcache/application_1571027248623_16676/container_e28_1571027248623_16676_01_000002/jvm-profiler-1.0.0.jar , timestamp= 1572856668
```