### PR TITLE
Add vmSize and vmPeak metrics in CpuAndMemoryProfiler

### DIFF
--- a/src/main/java/com/uber/profiling/profilers/CpuAndMemoryProfiler.java
+++ b/src/main/java/com/uber/profiling/profilers/CpuAndMemoryProfiler.java
@@ -171,6 +171,8 @@ public class CpuAndMemoryProfiler extends ProfilerBase implements Profiler {
         Map<String, String> procStatus = ProcFileUtils.getProcStatus();
         Long procStatusVmRSS = ProcFileUtils.getBytesValue(procStatus, "VmRSS");
         Long procStatusVmHWM = ProcFileUtils.getBytesValue(procStatus, "VmHWM");
+        Long procStatusVmSize = ProcFileUtils.getBytesValue(procStatus, "VmSize");
+        Long procStatusVmPeak = ProcFileUtils.getBytesValue(procStatus, "VmPeak");
 
         Map<String, Object> map = new HashMap<String, Object>();
 
@@ -210,9 +212,14 @@ public class CpuAndMemoryProfiler extends ProfilerBase implements Profiler {
         if (procStatusVmRSS != null) {
             map.put("vmRSS", procStatusVmRSS);
         }
-        
         if (procStatusVmHWM != null) {
             map.put("vmHWM", procStatusVmHWM);
+        }
+        if (procStatusVmSize != null) {
+            map.put("vmSize", procStatusVmSize);
+        }
+        if (procStatusVmPeak != null) {
+            map.put("vmPeak", procStatusVmPeak);
         }
 
         if (reporter != null) {

--- a/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
+++ b/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
@@ -9,8 +9,10 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Metrics reporter class for Graphite.
@@ -39,6 +41,8 @@ public class GraphiteOutputReporter implements Reporter {
   private Socket socket = null;
   private PrintWriter out = null;
 
+  private Set whiteList = new HashSet();
+
   @Override
   public void report(String profilerName, Map<String, Object> metrics) {
     // get DB connection
@@ -63,13 +67,15 @@ public class GraphiteOutputReporter implements Reporter {
     long timestamp = System.currentTimeMillis() / 1000;
     for (Map.Entry<String, Object> entry : formattedMetrics.entrySet()) {
       try {
-        out.printf(
-            newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+        if (whiteList.contains(entry.getKey())) {
+          out.printf(
+              newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+        }
       } catch (Exception e) {
-        logger.warn("Unable to print metrics, newPrefix="+newPrefix
-            +", entry.getKey()= "+ entry.getKey()
-            +", entry.getValue()= "+ entry.getValue()
-            +", timestamp= "+ timestamp);
+        logger.warn("Unable to print metrics, newPrefix=" + newPrefix
+            + ", entry.getKey()= " + entry.getKey()
+            + ", entry.getValue()= " + entry.getValue()
+            + ", timestamp= " + timestamp);
       }
     }
   }
@@ -193,6 +199,13 @@ public class GraphiteOutputReporter implements Reporter {
         } else if (key.equals("graphite.prefix")) {
           logger.info("Got value for database = " + stringValue);
           this.prefix = stringValue;
+        } else if (key.equals("graphite.whiteList")) {
+          logger.info("Got value for whiteList = " + stringValue);
+          if (stringValue != null && stringValue.length() > 0) {
+            for (String pattern : stringValue.split(",")) {
+              this.whiteList.add(pattern.trim());
+            }
+          }
         }
       }
     }

--- a/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
+++ b/src/main/java/com/uber/profiling/reporters/GraphiteOutputReporter.java
@@ -62,8 +62,15 @@ public class GraphiteOutputReporter implements Reporter {
     formattedMetrics.remove("processUuid");
     long timestamp = System.currentTimeMillis() / 1000;
     for (Map.Entry<String, Object> entry : formattedMetrics.entrySet()) {
-      out.printf(
-          newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+      try {
+        out.printf(
+            newPrefix + "." + entry.getKey() + " " + entry.getValue() + " " + timestamp + "%n");
+      } catch (Exception e) {
+        logger.warn("Unable to print metrics, newPrefix="+newPrefix
+            +", entry.getKey()= "+ entry.getKey()
+            +", entry.getValue()= "+ entry.getValue()
+            +", timestamp= "+ timestamp);
+      }
     }
   }
 

--- a/src/test/java/com/uber/profiling/util/ProcFileUtilsTest.java
+++ b/src/test/java/com/uber/profiling/util/ProcFileUtilsTest.java
@@ -35,6 +35,8 @@ public class ProcFileUtilsTest {
         file.deleteOnExit();
 
         String content = "Name:\tcat\t\n" 
+            + "VmSize:	     776 kB \r\n"
+            + "VmPeak:	     876 kB \r\n"
             + "VmRSS:	     676 kB \r\n"
             + "\t  Pid \t  : \t 66646 \t\n\r"
             + "Threads: \t 1 \t\n"
@@ -42,7 +44,7 @@ public class ProcFileUtilsTest {
         Files.write(file.toPath(), content.getBytes(), StandardOpenOption.CREATE);
 
         Map<String, String> result = ProcFileUtils.getProcFileAsMap(file.getPath());
-        Assert.assertEquals(4, result.size());
+        Assert.assertEquals(6, result.size());
         
         Assert.assertEquals("cat", result.get("Name"));
         Assert.assertEquals("676 kB", result.get("VmRSS"));
@@ -83,6 +85,8 @@ public class ProcFileUtilsTest {
         if (result.size() >= 1) {
             Assert.assertTrue(result.containsKey("Pid"));
             Assert.assertTrue(result.containsKey("VmRSS"));
+            Assert.assertTrue(result.containsKey("VmSize"));
+            Assert.assertTrue(result.containsKey("VmPeak"));
         }
     }
     


### PR DESCRIPTION
Yarn manages all running java containers . If a container runs beyond the memory limit, yarn will kill it. So we need to monitor the virtual memory usage of the container. 