### PR TITLE
Updating influxdb-java version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
                 <dependency>
                     <groupId>org.influxdb</groupId>
                     <artifactId>influxdb-java</artifactId>
-                    <version>2.7</version>
+                    <version>2.14</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
#### 1. Description:

1. This change is to fix the failing build for influxdb on the uber-common/jvm-profiler.

#### 2. Summary of Changes:

1. Updated `org.influxdb.influxdb-java` version in pom.xml.
2. Version updated with is a previously used version based on the git history.

#### 3. Test Runs:

##### 3.1. Before fix:

```
[INFO] BUILD FAILURE
:
:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile) on project jvm-profiler: Compilation failure: Compilation failure: 
[ERROR] /Users/mukund.vemuri/IdeaProjects/m-vemuri/uber-common/jvm-profiler/src/main/java_influxdb/com/uber/profiling/reporters/InfluxDBOutputReporter.java:[9,20] cannot find symbol
[ERROR]   symbol:   class BatchOptions
[ERROR]   location: package org.influxdb
[ERROR] /Users/mukund.vemuri/IdeaProjects/m-vemuri/uber-common/jvm-profiler/src/main/java_influxdb/com/uber/profiling/reporters/InfluxDBOutputReporter.java:[150,39] cannot find symbol
[ERROR]   symbol:   variable BatchOptions
[ERROR]   location: class com.uber.profiling.reporters.InfluxDBOutputReporter
```

##### 3.2. After fix:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.936 s
[INFO] Finished at: 2020-04-13T18:07:13-04:00
[INFO] ------------------------------------------------------------------------
```
#### 4. Reference Conversation:

Please refer to the conversation with one of the maintainers [here](https://github.com/uber-common/jvm-profiler/issues/67#issue-570830813).