### PR TITLE
[Feature] Adding ThreadMXBean information in the profiler #Issue52

### DIFF
--- a/src/main/java/com/uber/profiling/AgentImpl.java
+++ b/src/main/java/com/uber/profiling/AgentImpl.java
@@ -16,15 +16,7 @@
 
 package com.uber.profiling;
 
-import com.uber.profiling.profilers.CpuAndMemoryProfiler;
-import com.uber.profiling.profilers.IOProfiler;
-import com.uber.profiling.profilers.MethodArgumentCollector;
-import com.uber.profiling.profilers.MethodArgumentProfiler;
-import com.uber.profiling.profilers.MethodDurationCollector;
-import com.uber.profiling.profilers.MethodDurationProfiler;
-import com.uber.profiling.profilers.ProcessInfoProfiler;
-import com.uber.profiling.profilers.StacktraceCollectorProfiler;
-import com.uber.profiling.profilers.StacktraceReporterProfiler;
+import com.uber.profiling.profilers.*;
 import com.uber.profiling.transformers.JavaAgentFileTransformer;
 import com.uber.profiling.transformers.MethodProfilerStaticProxy;
 import com.uber.profiling.util.AgentLogger;
@@ -144,6 +136,15 @@ public class AgentImpl {
         cpuAndMemoryProfiler.setAppId(appId);
 
         profilers.add(cpuAndMemoryProfiler);
+
+        ThreadInfoProfiler threadInfoProfiler = new ThreadInfoProfiler(reporter);
+        threadInfoProfiler.setTag(tag);
+        threadInfoProfiler.setCluster(cluster);
+        threadInfoProfiler.setIntervalMillis(metricInterval);
+        threadInfoProfiler.setProcessUuid(processUuid);
+        threadInfoProfiler.setAppId(appId);
+
+        profilers.add(threadInfoProfiler);
 
         ProcessInfoProfiler processInfoProfiler = new ProcessInfoProfiler(reporter);
         processInfoProfiler.setTag(tag);

--- a/src/main/java/com/uber/profiling/profilers/ThreadInfoProfiler.java
+++ b/src/main/java/com/uber/profiling/profilers/ThreadInfoProfiler.java
@@ -1,0 +1,102 @@
+package com.uber.profiling.profilers;
+
+
+import com.uber.profiling.Agent;
+import com.uber.profiling.Profiler;
+import com.uber.profiling.Reporter;
+import com.uber.profiling.util.AgentLogger;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ThreadInfoProfiler is used to Collects the Thread Related Metrics.
+ */
+public class ThreadInfoProfiler extends ProfilerBase implements Profiler {
+    public final static String PROFILER_NAME = "ThreadInfo";
+    public final static AgentLogger logger = AgentLogger.getLogger(ThreadInfoProfiler.class.getName());
+    private long intervalMillis = Constants.DEFAULT_METRIC_INTERVAL;
+
+    private ThreadMXBean threadMXBean;
+    private long previousTotalThreadCount = 0L; // to keep track of Total Thread.
+
+    private Reporter reporter;
+
+    public ThreadInfoProfiler(Reporter reporter) {
+        setReporter(reporter);
+        init();
+    }
+
+    private void init() {
+        try {
+            this.threadMXBean = ManagementFactory.getThreadMXBean();
+        }
+        catch (Throwable ex) {
+            logger.warn("Failed to get Thread MXBean", ex);
+        }
+
+    }
+
+    public void setIntervalMillis(long intervalMillis) {
+        this.intervalMillis = intervalMillis;
+    }
+
+    @Override
+    public long getIntervalMillis() {
+        return intervalMillis;
+    }
+
+    @Override
+    public void setReporter(Reporter reporter) {
+        this.reporter = reporter;
+    }
+
+    @Override
+    public void profile() {
+
+        long totalThreadCount = 0L; // total Thread created so far since JVm Launch.
+        int liveThreadCount = 0; // Number of thread which are currently active.
+        int peakThreadCount = 0; // the peak live thread count since the Java virtual machine started or peak was reset
+        long newThreadCount = 0; // Number of new thread created since last time time the metrics was created.
+                                 // This is a Derived metrics from previous data point.
+        if (threadMXBean != null) {
+            liveThreadCount =  threadMXBean.getThreadCount();
+            peakThreadCount = threadMXBean.getPeakThreadCount();
+            totalThreadCount = threadMXBean.getTotalStartedThreadCount();
+            newThreadCount = totalThreadCount - this.previousTotalThreadCount;
+            this.previousTotalThreadCount = totalThreadCount;
+        }
+
+        Map<String, Object> map = new HashMap<String, Object>();
+
+        map.put("epochMillis", System.currentTimeMillis());
+        map.put("name", getProcessName());
+        map.put("host", getHostName());
+        map.put("processUuid", getProcessUuid());
+        map.put("appId", getAppId());
+
+        if (getTag() != null) {
+            map.put("tag", getTag());
+        }
+
+        if (getCluster() != null) {
+            map.put("cluster", getCluster());
+        }
+
+        if (getRole() != null) {
+            map.put("role", getRole());
+        }
+
+        map.put("totalThreadCount", totalThreadCount);
+        map.put("newThreadCount", newThreadCount);
+        map.put("liveThreadCount", liveThreadCount);
+        map.put("peakThreadCount", peakThreadCount);
+
+        if (reporter != null) {
+            reporter.report(PROFILER_NAME, map);
+        }
+    }
+
+}

--- a/src/test/java/com/uber/profiling/profilers/ThreadInfoProfilerTest.java
+++ b/src/test/java/com/uber/profiling/profilers/ThreadInfoProfilerTest.java
@@ -1,0 +1,47 @@
+package com.uber.profiling.profilers;
+
+import com.uber.profiling.Reporter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ThreadInfoProfilerTest {
+    @Test
+    public void profile() {
+        final List<String> nameList = new ArrayList<>();
+        final List<Map<String, Object>> metricList = new ArrayList<>();
+
+        // create a Profile Instance.
+        ThreadInfoProfiler profiler = new ThreadInfoProfiler(new Reporter() {
+            @Override
+            public void report(String profilerName, Map<String, Object> metrics) {
+                nameList.add(profilerName);
+                metricList.add(metrics);
+            }
+
+            @Override
+            public void close() {
+
+            }
+        });
+        // Set interval
+        profiler.setIntervalMillis(150);
+        Assert.assertEquals(150L, profiler.getIntervalMillis());
+
+        // run 2 cycles on the profile.
+        profiler.profile();
+        profiler.profile();
+
+        Assert.assertEquals(2, nameList.size());
+        Assert.assertEquals(ThreadInfoProfiler.PROFILER_NAME, nameList.get(0));
+
+        Assert.assertEquals(2, metricList.size());
+        Assert.assertTrue(metricList.get(0).containsKey("totalThreadCount"));
+        Assert.assertTrue(metricList.get(0).containsKey("newThreadCount"));
+        Assert.assertTrue(metricList.get(0).containsKey("liveThreadCount"));
+        Assert.assertTrue(metricList.get(0).containsKey("peakThreadCount"));
+    }
+}

--- a/src/test/java/com/uber/profiling/profilers/ThreadInfoProfilerTest.java
+++ b/src/test/java/com/uber/profiling/profilers/ThreadInfoProfilerTest.java
@@ -35,6 +35,7 @@ public class ThreadInfoProfilerTest {
         profiler.profile();
         profiler.profile();
 
+        //start assertion.
         Assert.assertEquals(2, nameList.size());
         Assert.assertEquals(ThreadInfoProfiler.PROFILER_NAME, nameList.get(0));
 


### PR DESCRIPTION
As per the discussion on https://github.com/uber-common/jvm-profiler/issues/52, adding Support for Collecting Some stats related to JVM Threads. 

1. A new Profiler called `ThreadInfoProfiler` is added which makes use of `ThreadMXBean` to Collect and report the Stats.
2. Unit Tests for the same are added.

The Metric Looks like the following:
```
ConsoleOutputReporter - ThreadInfo: {"liveThreadCount":6,"appId":null,"name":"52769@MacBook-Pro.local","host":"MacBook-Pro.local","processUuid":"923a1e00-1413-4fd5-800b-08764ea1faaf","totalThreadCount":6,"epochMillis":1601806705706,"tag":"mytag","peakThreadCount":6,"newThreadCount":0}
```

Please review and let me know if I have missed anything.