### PR TITLE
Add client id to kafka producer properties

### DIFF
--- a/src/main/java/com/uber/profiling/reporters/KafkaOutputReporter.java
+++ b/src/main/java/com/uber/profiling/reporters/KafkaOutputReporter.java
@@ -166,6 +166,7 @@ public class KafkaOutputReporter implements Reporter {
             props.put("buffer.memory", 16384000);
             props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
             props.put("value.serializer", org.apache.kafka.common.serialization.ByteArraySerializer.class.getName());
+            props.put("client.id", "jvm-profilers");
 
             if (syncMode) {
                 props.put("acks", "all");


### PR DESCRIPTION
Add client id information into Kafka reporter property. It would be better if we inject multiple clients in the same jar.